### PR TITLE
Support for decrypting an empty String message body

### DIFF
--- a/src/main/java/no/cantara/aws/sqs/JsonUtil.java
+++ b/src/main/java/no/cantara/aws/sqs/JsonUtil.java
@@ -1,17 +1,21 @@
 package no.cantara.aws.sqs;
 
+import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 final class JsonUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     static <T extends Object> String from(Map<T, Object> map) {
         try {
-            return new ObjectMapper().writeValueAsString(map);
+            return objectMapper.writeValueAsString(map);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -19,7 +23,10 @@ final class JsonUtil {
 
     static Map<Object, Object> toMap(String json) {
         try {
-            return new ObjectMapper().readValue(json, new TypeReference<HashMap<Object, Object>>() {});
+            if (StringUtils.isNullOrEmpty(json)) {
+                return Collections.emptyMap();
+            }
+            return objectMapper.readValue(json, TypeFactory.defaultInstance().constructMapType(HashMap.class, Object.class, Object.class));
         } catch (IOException io) {
             throw new RuntimeException(io);
         }

--- a/src/test/java/no/cantara/aws/sqs/SecureSqsIntegrationTest.java
+++ b/src/test/java/no/cantara/aws/sqs/SecureSqsIntegrationTest.java
@@ -84,6 +84,22 @@ public class SecureSqsIntegrationTest {
     }
 
     @Test
+    public void testSQSMessageWithEmptyBody() throws InterruptedException {
+        GetQueueUrlResult queueUrl = sqsClient.getQueueUrl(QUEUE_NAME);
+        String emptyBody = "";
+
+        log.debug("Sending message with empty payload to queue={}", queueUrl);
+        sqsClient.sendMessage(queueUrl.getQueueUrl(), emptyBody);
+        Message message = sqsClient.receiveMessage(queueUrl.getQueueUrl()).getMessages().get(0);
+        String messageContent = message.getBody();
+
+        assertEquals(messageContent, emptyBody);
+
+        log.debug("Deleting test message from queue {}", queueUrl);
+        sqsClient.deleteMessage(queueUrl.getQueueUrl(), message.getReceiptHandle());
+    }
+
+    @Test
     public void testSQSMessageWithSNSNotification() throws InterruptedException {
         sqsClient.withSnsNotificationsEnabled(QUEUE_NAME, true);
         GetQueueUrlResult queueUrl = sqsClient.getQueueUrl(QUEUE_NAME);


### PR DESCRIPTION
Added support for empty String as an SQS message body. 

Null values are not supported by sqs, but an empty String "" is allowed. Decryption of an empty String used to throw an exception.