### PR TITLE
KMSCryptoUtil -> KmsCryptoClient with state

### DIFF
--- a/src/main/java/no/cantara/aws/sqs/AmazonS3ClientBase.java
+++ b/src/main/java/no/cantara/aws/sqs/AmazonS3ClientBase.java
@@ -47,8 +47,6 @@ public class AmazonS3ClientBase implements AmazonS3 {
         return delegate.setObjectRetention(var1);
     }
 
-    ;
-
     @Override
     public GetObjectRetentionResult getObjectRetention(GetObjectRetentionRequest var1) {
         return delegate.getObjectRetention(var1);

--- a/src/test/java/no/cantara/aws/sqs/SecureSqsIntegrationTest.java
+++ b/src/test/java/no/cantara/aws/sqs/SecureSqsIntegrationTest.java
@@ -5,7 +5,6 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.model.NotFoundException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
@@ -28,7 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-import static no.cantara.aws.sqs.KMSCryptoUtil.DEFAULT_CMK;
+import static no.cantara.aws.sqs.KmsCryptoClient.DEFAULT_CMK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -180,7 +179,7 @@ public class SecureSqsIntegrationTest {
 
     @Test(expected = NotFoundException.class)
     public void testInvalidCmk() {
-        KMSCryptoUtil.encrypt(Region.getRegion(REGION), "invalid_id", "{}");
+        new KmsCryptoClient().encrypt("invalid_id", "{}");
     }
 
     @Test


### PR DESCRIPTION
Move responsibility for regional managing of multiple kms-client to
application that uses the sqs-util-library. As AmazonSQSSecureClient
instances are created with one region in mind there is no reason for
KMSCryptoUtil to have kmsClient-per-region state. We remove an
(unneeded) optimization in order to gain the flexibility to customize
your own kmsClient (for proxy usage and such).

Also some code cleanup.