### PR TITLE
Fix for NPE in generateDataKey while encrypting a message

### DIFF
--- a/src/main/java/no/cantara/aws/sqs/AmazonSQSSecureClient.java
+++ b/src/main/java/no/cantara/aws/sqs/AmazonSQSSecureClient.java
@@ -191,7 +191,7 @@ public class AmazonSQSSecureClient extends AmazonSQSClientBase {
             final Regions awsRegion
     ) {
         final AWSKMS awsKmsClient = AWSKMSClientBuilder.standard()
-                .withRegion(awsRegion.toString())
+                .withRegion(awsRegion)
                 .withCredentials(awsCredentialsProvider)
                 .build();
         return new KmsCryptoClient(awsKmsClient);


### PR DESCRIPTION
This seems to cause problems with encrypting things down the line. This results in the URI created in AmazonWebServiceClient.setRegion() to create an URI without a host, which again causes a NPE while running generateDataKey()