### PR TITLE
fixes an issue where SendMessageBatchRequest can get to big

### DIFF
--- a/src/main/java/no/cantara/aws/sqs/BatchEntry.java
+++ b/src/main/java/no/cantara/aws/sqs/BatchEntry.java
@@ -1,0 +1,21 @@
+package no.cantara.aws.sqs;
+
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
+
+public class BatchEntry {
+    private final String encryptedPayload;
+    private final SendMessageBatchRequestEntry batchRequestEntry;
+
+    public BatchEntry(String encryptedPayload, SendMessageBatchRequestEntry batchRequestEntry) {
+        this.encryptedPayload = encryptedPayload;
+        this.batchRequestEntry = batchRequestEntry;
+    }
+
+    public String getEncryptedPayload() {
+        return encryptedPayload;
+    }
+
+    public SendMessageBatchRequestEntry getBatchRequestEntry() {
+        return batchRequestEntry;
+    }
+}


### PR DESCRIPTION
> The maximum allowed individual message size and the maximum total payload size (the sum of the individual lengths of all of the batched messages) are both 256 KB (262,144 bytes). 
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html

Previously this only checked individual messages in the batch, but a batch request has the same max size requirement as a normal messagerequest. Thus this would fail if all the messages are smaller than MAX_MESSAGE_SIZE, but the total size is bigger. This fixes this by calculating the total size before creating the batch entries.

Also refactored the message attribute creation to be reused between a normal request and a batch request.